### PR TITLE
Incorrect file reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: c

--- a/src/Platform/OSX/System/Context.c
+++ b/src/Platform/OSX/System/Context.c
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <string.h>
-#include "context.h"
+#include "Context.h"
 
 void
 makecontext(uctx *ucp, void (*func)(void), intptr_t arg)


### PR DESCRIPTION
This references context.h, which is non-existant and a fatal error when compiling. However, since this is on the OS X branch, some users may not notice this. A change to Context.h will fix the issue.